### PR TITLE
fix(seo): noindex incomplete /explore taxonomy stubs and exclude them from sitemap

### DIFF
--- a/apps/next/app/explore/[id]/page.tsx
+++ b/apps/next/app/explore/[id]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation'
 
 import { ASSETS_BASE_URL } from '@/app/lib/api/constants'
 import DiscoveryDetailScreen from '@/app/screens/ExploreDetail'
-import { getOrganism } from '@/next/lib/db'
+import { getOrganism, isOrganismIndexable } from '@/next/lib/db'
 
 type Props = {
 	params: Promise<{ id: string }>
@@ -21,6 +21,13 @@ export async function generateMetadata({ params }: Props) {
 
 	return {
 		description: organism.description,
+		// Incomplete taxonomy stubs (missing common name, description, or species)
+		// are thin pages that Google flags as "Crawled - currently not indexed".
+		// Mark them noindex (but keep follow so link equity still flows) while
+		// leaving complete organisms fully indexable.
+		...(isOrganismIndexable(organism)
+			? null
+			: { robots: { follow: true, index: false } }),
 		title: organism.common_name,
 	}
 }

--- a/apps/next/app/sitemap.ts
+++ b/apps/next/app/sitemap.ts
@@ -7,7 +7,11 @@ export const revalidate = 3600
 const origin = process.env.NEXT_PUBLIC_ORIGIN
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-	const organisms = await getOrganisms()
+	// Fetch the full organism set rather than the default 50-row page: the
+	// completeness filter below must see every organism, otherwise incomplete
+	// stubs sorting into the first page would shrink the sitemap and push
+	// complete, indexable organisms out of it. 50,000 is the per-sitemap URL cap.
+	const organisms = await getOrganisms({ limit: 50_000 })
 
 	return [
 		{

--- a/apps/next/app/sitemap.ts
+++ b/apps/next/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next'
 
-import { getOrganisms } from '@/next/lib/db'
+import { getOrganisms, isOrganismIndexable } from '@/next/lib/db'
 
 export const revalidate = 3600
 
@@ -20,7 +20,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			priority: 1,
 			url: `${origin}/explore`,
 		},
-		...organisms.map((organism) => ({
+		// Only emit complete organisms. Incomplete taxonomy stubs are marked
+		// noindex on their detail page, so keeping them out of the sitemap avoids
+		// advertising thin URLs that drag down crawl quality.
+		...organisms.filter(isOrganismIndexable).map((organism) => ({
 			lastModified: organism.updated_at,
 			priority: 1,
 			url: `${origin}/explore/${organism.id}`,

--- a/apps/next/lib/db.ts
+++ b/apps/next/lib/db.ts
@@ -55,6 +55,23 @@ export const db = new Kysely<Database>({
 	}),
 })
 
+/**
+ * An organism is considered "complete enough to index" only when it has real,
+ * non-empty content across all of: common name, description, and a species-level
+ * classification. Incomplete stubs (e.g. a genus with a trailing-dash slug and no
+ * species) are thin pages that Google reports as "Crawled - currently not indexed",
+ * so they should be excluded from the sitemap and marked noindex.
+ */
+export function isOrganismIndexable(
+	organism: Pick<Organism, 'common_name' | 'description' | 'classification'>,
+): boolean {
+	return Boolean(
+		organism.common_name?.trim() &&
+			organism.description?.trim() &&
+			organism.classification?.species?.trim(),
+	)
+}
+
 type GetOrganismsOptions = {
 	sortBy?: UndirectedOrderByExpression<Database, 'organisms', object>
 	direction?: 'asc' | 'desc'


### PR DESCRIPTION
## Problem

Google Search Console reports hundreds of `/explore/[id]` taxonomy pages as **"Crawled - currently not indexed"**. Many of these are incomplete stubs (e.g. a genus with a trailing-dash slug like `formicidae-atta-` and no species, often missing common name, description, or image). These thin pages drag down the domain's overall crawl quality and waste crawl budget on URLs Google will never index anyway.

## Change

Introduce a shared completeness predicate and apply it in both the detail page and the sitemap so incomplete entries are kept out of the index while complete ones stay fully indexable.

**Completeness rule** (`isOrganismIndexable` in `apps/next/lib/db.ts`): an organism is indexable only when it has ALL of:
- non-empty `common_name`
- non-empty `description`
- non-empty `classification.species`

If any is missing/empty → incomplete (the trailing-dash stubs lack `species`).

### `apps/next/app/explore/[id]/page.tsx`
`generateMetadata` now returns `robots: { index: false, follow: true }` for incomplete organisms (noindex, but `follow` kept so link equity still flows). Complete organisms get no robots override and stay indexable. The `notFound()` behavior and the rendered page are unchanged.

### `apps/next/app/sitemap.ts`
Incomplete organisms are filtered out, so only complete `/explore/[id]` URLs are advertised to crawlers.

`robots.ts` and `opengraph-image.tsx` are intentionally left as-is.

## Verification
- `bun run typecheck` (tsc --noEmit) — passes clean.
- `bunx eslint` on the three changed files — passes clean (0 problems). Note: repo-wide `bun run lint` reports one **pre-existing** error in `app/styles-provider.tsx`, unrelated to this PR and present on `main`.
- `bun run build` (`next build --experimental-build-mode compile`) — compiles successfully; `/explore/[id]` and `/sitemap.xml` build without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)